### PR TITLE
Specify Dockerfile path in Docker build command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t tournament-master-api .
+          docker build -t tournament-master-api -f TournamentMaster.API/TournamentMaster.API/Dockerfile .
           docker tag tournament-master-api:latest ${{ secrets.ECR_REPOSITORY_URI }}:latest
 
       - name: Push Docker image to ECR


### PR DESCRIPTION
Updated the `docker build` command to explicitly reference the `TournamentMaster.API/TournamentMaster.API/Dockerfile` file. This ensures the correct Dockerfile is used, improving build precision and avoiding conflicts with other Dockerfiles in the project.